### PR TITLE
Destructuring renaming generic selector variables

### DIFF
--- a/libs/core-data/src/lib/state/customers/customers.reducer.ts
+++ b/libs/core-data/src/lib/state/customers/customers.reducer.ts
@@ -27,14 +27,12 @@ export function customersReducer(
 }
 
 // get the selectors
-const { selectIds, selectEntities, selectAll } = adapter.getSelectors();
-
-// select the array of widget ids
-export const selectCustomerIds = selectIds;
-
-// select the dictionary of widget entities
-export const selectCustomerEntities = selectEntities;
-
-// select the array of widgets
-export const selectAllCustomers = selectAll;
+export const {
+  // select the array of widget ids
+  selectIds: selectCustomerIds,
+  // select the dictionary of widget entities
+  selectEntities: selectCustomerEntities,
+  // select the array of widgets
+  selectAll: selectAllCustomers
+} = adapter.getSelectors();
 

--- a/libs/core-data/src/lib/state/projects/projects.reducer.ts
+++ b/libs/core-data/src/lib/state/projects/projects.reducer.ts
@@ -47,16 +47,13 @@ export function projectsReducer(state = initialState, action: ProjectsActions): 
 export const getSelectedProjectId = (state: ProjectsState) => state.selectedProjectId;
 
 // get the selectors
-const { selectIds, selectEntities, selectAll, selectTotal } = adapter.getSelectors();
-
-// select the array of project ids
-export const selectProjectIds = selectIds;
-
-// select the dictionary of project entities
-export const selectProjectEntities = selectEntities;
-
-// select the array of projects
-export const selectAllProjects = selectAll;
-
-// select the total project count
-export const selectProjectTotal = selectTotal;
+export const {
+  // select the array of project ids
+  selectIds: selectProjectIds,
+  // select the dictionary of project entities
+  selectEntities: selectProjectEntities,
+  // select the array of projects
+  selectAll: selectAllProjects,
+  // select the total project count
+  selectTotal: selectProjectTotal
+} = adapter.getSelectors();


### PR DESCRIPTION
Since `getSelectors` always gives us the generic names (`selectIds`, `selectEntities` etc.) renaming in tandem with destructuring ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Assigning_to_new_variable_names)) is a handy pattern we can use to give those selectors developer friendly names.